### PR TITLE
Adding Redis Strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+go-longpolling

--- a/main.go
+++ b/main.go
@@ -6,10 +6,12 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
+	"os"
+
 	"./models"
+	"./redis"
 	"./strategies"
 )
 
@@ -94,9 +96,14 @@ func main() {
 		serverAddress = os.Args[1]
 	}
 
+	strategy, err := strategies.NewRedisStrategy(redis.ConfigFromEnv())
+	if err != nil {
+		panic(err)
+	}
+
 	s := server{
 		log:      models.StdLogger,
-		Strategy: strategies.NewStdBasic(),
+		Strategy: strategy,
 		Address:  serverAddress,
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"./models"
@@ -14,9 +15,10 @@ import (
 
 // Strategy is an interface for pub/sub strategies
 type Strategy interface {
+	Setup()
 	Add(s *models.Connection, channel string) error
 	Remove(uuid, channel string) error
-	Publish(channel string, r io.ReadCloser) error
+	Publish(channel string, r io.Reader) error
 }
 
 type server struct {
@@ -80,6 +82,7 @@ func (s *server) indexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) setup() {
+	s.Strategy.Setup()
 	http.HandleFunc("/", s.indexHandler)
 	http.HandleFunc("/subscribe", s.subscribeHandler)
 	http.HandleFunc("/publish", s.publishHanlder)
@@ -87,6 +90,9 @@ func (s *server) setup() {
 
 func main() {
 	var serverAddress = ":8080"
+	if len(os.Args) == 2 {
+		serverAddress = os.Args[1]
+	}
 
 	s := server{
 		log:      models.StdLogger,

--- a/redis/config.go
+++ b/redis/config.go
@@ -1,0 +1,61 @@
+package redis
+
+import (
+	"log"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+var (
+	err error
+)
+
+const (
+	timeout           time.Duration = 4 * time.Minute
+	connectTimeout    time.Duration = 10 * time.Second
+	defaultRedisConns               = 4
+)
+
+// Config holds the redis configuration
+type Config struct {
+	ServerURL, Auth string
+	Database        string
+	PoolSize        int
+}
+
+// ConfigFromEnv returns a config objects that reads everything from the
+// environment and adds some sensible defaults.
+func ConfigFromEnv() *Config {
+	config := &Config{
+		Database: os.Getenv("REDIS_DATABASE"),
+	}
+
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		redisURL = "127.0.0.1:6379"
+	}
+
+	srvURL, err := url.Parse(redisURL)
+	if err != nil {
+		panic("[ERROR] Could not parse REDIS_URL: " + redisURL)
+	}
+
+	if srvURL.User == nil {
+		config.ServerURL = srvURL.String()
+	} else {
+		config.ServerURL = srvURL.Host
+		config.Auth, _ = srvURL.User.Password()
+	}
+
+	redisConnEnv := os.Getenv("REDIS_POOL_SIZE")
+	if redisConnEnv != "" {
+		config.PoolSize, err = strconv.Atoi(redisConnEnv)
+		if err != nil {
+			log.Printf("[ERROR] Could not parse Redis pool size: %s. Using default size (%d)", redisConnEnv, defaultRedisConns)
+			config.PoolSize = defaultRedisConns
+		}
+	}
+	return config
+}

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -1,0 +1,22 @@
+package redis
+
+import "github.com/garyburd/redigo/redis"
+
+// NewPubSub returns a Redis pubsub connection from a config.
+func NewPubSub(cnf *Config) (*redis.PubSubConn, error) {
+	conn, err := New(cnf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &redis.PubSubConn{Conn: conn}, nil
+}
+
+// New returns a new redis connection given some config.
+func New(cnf *Config) (redis.Conn, error) {
+	return redis.Dial(
+		"tcp",
+		cnf.ServerURL,
+		redis.DialPassword(cnf.Auth),
+	)
+}

--- a/strategies/basic.go
+++ b/strategies/basic.go
@@ -23,6 +23,11 @@ func NewStdBasic() *Basic {
 	}
 }
 
+// Setup does nothing
+func (b *Basic) Setup() {
+	// no-op
+}
+
 // Add subscribes a subscription to it's channel
 func (b *Basic) Add(c *models.Connection, channel string) error {
 	b.Lock()
@@ -57,12 +62,11 @@ func (b *Basic) Remove(uuid, channel string) error {
 }
 
 // Publish sends the messages to the users
-func (b *Basic) Publish(channel string, r io.ReadCloser) error {
+func (b *Basic) Publish(channel string, r io.Reader) error {
 	msg, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 
 	b.log.Printf("Publishing to channel %s: %d\n", channel, len(b.subs[channel]))
 	for _, conn := range b.subs[channel] {
@@ -70,4 +74,10 @@ func (b *Basic) Publish(channel string, r io.ReadCloser) error {
 		conn.C <- msg
 	}
 	return nil
+}
+
+func (b *Basic) totalSubs(channel string) int {
+	b.Lock()
+	defer b.Unlock()
+	return len(b.subs[channel])
 }

--- a/strategies/redis.go
+++ b/strategies/redis.go
@@ -1,0 +1,97 @@
+package strategies
+
+import (
+	"bytes"
+	"io"
+	"log"
+
+	"../models"
+	"../redis"
+
+	"io/ioutil"
+
+	client "github.com/garyburd/redigo/redis"
+)
+
+type Redis struct {
+	*client.PubSubConn
+
+	b   *Basic
+	cnf *redis.Config
+}
+
+func (r *Redis) conn() (client.Conn, error) {
+	return redis.New(r.cnf)
+}
+
+// NewRedisStrategy returns a long polling strategy based on Redis Pub/Sub
+func NewRedisStrategy(cnf *redis.Config) (*Redis, error) {
+	conn, err := redis.NewPubSub(cnf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Redis{
+		b:          NewStdBasic(),
+		cnf:        cnf,
+		PubSubConn: conn,
+	}, nil
+}
+
+// Setup starts the `Receive` method
+func (r *Redis) Setup() {
+	go r.receive()
+}
+
+// Add subscribes a subscription to it's channel
+func (r *Redis) Add(c *models.Connection, channel string) error {
+	if err := r.b.Add(c, channel); err != nil {
+		return err
+	}
+	return r.Subscribe(channel)
+}
+
+// Remove removes a connection from a channel
+func (r *Redis) Remove(uuid, channel string) error {
+	if err := r.b.Remove(uuid, channel); err != nil {
+		return err
+	}
+
+	if r.b.totalSubs(channel) == 0 {
+		return r.Unsubscribe(channel)
+	}
+
+	return nil
+}
+
+// Publish sends the messages to the users
+func (r *Redis) Publish(channel string, rc io.Reader) error {
+	c, err := r.conn()
+	if err != nil {
+		return err
+	}
+	str := readAll(rc)
+	log.Printf("[redis] Publishing to %s: %s", channel, str)
+	c.Do("PUBLISH", channel, str)
+	return c.Close()
+}
+
+func (r *Redis) receive() {
+	for {
+		switch v := r.PubSubConn.Receive().(type) {
+		case client.Message:
+			log.Printf("[redis] Received on channel %s: %s", v.Channel, string(v.Data))
+			r.b.Publish(v.Channel, bytes.NewReader(v.Data))
+		case client.Subscription:
+			// Do nothing
+		case error:
+			log.Println("error pub/sub on connection, delivery has stopped")
+			return
+		}
+	}
+}
+
+func readAll(r io.Reader) string {
+	b, _ := ioutil.ReadAll(r)
+	return string(b)
+}


### PR DESCRIPTION
This strategy uses Redis PUB/SUB to communicate messages to subscribers in different servers. The idea is to connect multiple `Basic` strategies with Redis pub/sub.

When a new message is published, the server that receives the request will forward it to all other servers with Redis. When each server gets the message, they will `Publish` it to the clients they have connected (the ones in their own basic strategy).
