### PR TITLE
Adding tests for the Basic strategy

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func (s *server) publishHanlder(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("Message sent!")))
 }
 
-// publishHanlder is the HTTP handler publish messages to a channel
+// indexHandler will serve the index.html file
 func (s *server) indexHandler(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadFile("index.html")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -14,16 +14,8 @@ import (
 	"./strategies"
 )
 
-// Strategy is an interface for pub/sub strategies
-type Strategy interface {
-	Setup()
-	Add(s *models.Connection, channel string) error
-	Remove(uuid, channel string) error
-	Publish(channel string, r io.Reader) error
-}
-
 type server struct {
-	Strategy
+	strategies.Strategy
 	log     models.Logger
 	Address string
 }

--- a/models/models.go
+++ b/models/models.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"os"
 
+	"io/ioutil"
+
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -28,9 +30,13 @@ func NewConnection() *Connection {
 	}
 }
 
-// StdLogger logs to STDOUT
-var StdLogger Logger
+// Default loggers.
+var (
+	StdLogger  Logger
+	NullLogger Logger
+)
 
 func init() {
 	StdLogger = log.New(os.Stdout, "", log.LstdFlags)
+	NullLogger = log.New(ioutil.Discard, "", log.LstdFlags)
 }

--- a/models/models.go
+++ b/models/models.go
@@ -1,10 +1,9 @@
 package models
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
-
-	"io/ioutil"
 
 	uuid "github.com/satori/go.uuid"
 )

--- a/redis/config.go
+++ b/redis/config.go
@@ -1,10 +1,8 @@
 package redis
 
 import (
-	"log"
 	"net/url"
 	"os"
-	"strconv"
 	"time"
 )
 
@@ -21,16 +19,12 @@ const (
 // Config holds the redis configuration
 type Config struct {
 	ServerURL, Auth string
-	Database        string
-	PoolSize        int
 }
 
 // ConfigFromEnv returns a config objects that reads everything from the
 // environment and adds some sensible defaults.
 func ConfigFromEnv() *Config {
-	config := &Config{
-		Database: os.Getenv("REDIS_DATABASE"),
-	}
+	config := &Config{}
 
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {
@@ -49,13 +43,5 @@ func ConfigFromEnv() *Config {
 		config.Auth, _ = srvURL.User.Password()
 	}
 
-	redisConnEnv := os.Getenv("REDIS_POOL_SIZE")
-	if redisConnEnv != "" {
-		config.PoolSize, err = strconv.Atoi(redisConnEnv)
-		if err != nil {
-			log.Printf("[ERROR] Could not parse Redis pool size: %s. Using default size (%d)", redisConnEnv, defaultRedisConns)
-			config.PoolSize = defaultRedisConns
-		}
-	}
 	return config
 }

--- a/strategies/basic.go
+++ b/strategies/basic.go
@@ -76,7 +76,8 @@ func (b *Basic) Publish(channel string, r io.Reader) error {
 	return nil
 }
 
-func (b *Basic) totalSubs(channel string) int {
+// TotalSubs returns the number of subscribers in a channel
+func (b *Basic) TotalSubs(channel string) int {
 	b.Lock()
 	defer b.Unlock()
 	return len(b.subs[channel])

--- a/strategies/basic_test.go
+++ b/strategies/basic_test.go
@@ -1,0 +1,49 @@
+package strategies
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"../models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicStrategy(t *testing.T) {
+	strategy := Basic{
+		log: models.NullLogger,
+	}
+
+	events := models.NewConnection()
+	messages := models.NewConnection()
+
+	assert.NoError(t, strategy.Add(events, "events"))
+	assert.NoError(t, strategy.Add(messages, "messages"))
+
+	assert.Equal(t, 1, strategy.TotalSubs("events"))
+	assert.Equal(t, 1, strategy.TotalSubs("messages"))
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go assertEvent(t, events, wg)
+	go assertNoEvent(t, messages, wg)
+	strategy.Publish("events", bytes.NewReader([]byte(`Hello, World!`)))
+	wg.Wait()
+
+	wg.Add(2)
+	go assertEvent(t, messages, wg)
+	go assertNoEvent(t, events, wg)
+	strategy.Publish("messages", bytes.NewReader([]byte(`Hello, World!`)))
+	wg.Wait()
+
+	assert.Equal(t, 1, strategy.TotalSubs("events"))
+	assert.Equal(t, 1, strategy.TotalSubs("messages"))
+
+	assert.NoError(t, strategy.Remove(events.ID, "events"))
+	assert.NoError(t, strategy.Remove(messages.ID, "events"))
+	assert.NoError(t, strategy.Remove(messages.ID, "messages"))
+	assert.NoError(t, strategy.Remove(messages.ID, "messages"))
+
+	assert.Equal(t, 0, strategy.TotalSubs("events"))
+	assert.Equal(t, 0, strategy.TotalSubs("messages"))
+}

--- a/strategies/redis.go
+++ b/strategies/redis.go
@@ -16,7 +16,7 @@ import (
 type Redis struct {
 	*client.PubSubConn
 
-	b   *Basic
+	b   Strategy
 	cnf *redis.Config
 }
 
@@ -57,7 +57,7 @@ func (r *Redis) Remove(uuid, channel string) error {
 		return err
 	}
 
-	if r.b.totalSubs(channel) == 0 {
+	if r.TotalSubs(channel) == 0 {
 		return r.Unsubscribe(channel)
 	}
 
@@ -74,6 +74,11 @@ func (r *Redis) Publish(channel string, rc io.Reader) error {
 	log.Printf("[redis] Publishing to %s: %s", channel, str)
 	c.Do("PUBLISH", channel, str)
 	return c.Close()
+}
+
+// TotalSubs returns the number of subscribers in a channel
+func (r *Redis) TotalSubs(channel string) int {
+	return r.b.TotalSubs(channel)
 }
 
 func (r *Redis) receive() {

--- a/strategies/strategies_test.go
+++ b/strategies/strategies_test.go
@@ -1,0 +1,31 @@
+package strategies
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"../models"
+)
+
+func assertEvent(t *testing.T, c *models.Connection, wg *sync.WaitGroup) {
+	select {
+	case <-c.C:
+		// no-op
+	case <-time.After(1 * time.Second):
+		t.Errorf("Did not get event")
+		t.Fail()
+	}
+	wg.Done()
+}
+
+func assertNoEvent(t *testing.T, c *models.Connection, wg *sync.WaitGroup) {
+	select {
+	case <-c.C:
+		t.Errorf("Got event when none was expected")
+		t.Fail()
+	case <-time.After(300 * time.Millisecond):
+		// no-op
+	}
+	wg.Done()
+}

--- a/strategies/strategy.go
+++ b/strategies/strategy.go
@@ -1,0 +1,16 @@
+package strategies
+
+import (
+	"io"
+
+	"../models"
+)
+
+// Strategy is an interface for pub/sub strategies
+type Strategy interface {
+	Setup()
+	Add(s *models.Connection, channel string) error
+	Remove(uuid, channel string) error
+	Publish(channel string, r io.Reader) error
+	TotalSubs(channel string) int
+}


### PR DESCRIPTION
This commit adds tests for the `Basic` strategy. The test will add connections to multiple channels and test that publishing to those channels will send the message to the expected connections (and only those).