### PR TITLE
Adding tests for Redis strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 go-longpolling
+dump.rdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+services:
+  - redis-server
+
 go:
   - 1.x
   - 1.7.x

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		serverAddress = os.Args[1]
 	}
 
-	// strategy, err := strategies.NewRedisStrategy(redis.ConfigFromEnv())
+	// strategy, err := strategies.NewRedisStrategy(redis.ConfigFromEnv(nil))
 	// if err != nil {
 	// 	panic(err)
 	// }

--- a/redis/config.go
+++ b/redis/config.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"net/url"
 	"os"
 	"time"
 )
@@ -30,18 +29,6 @@ func ConfigFromEnv() *Config {
 	if redisURL == "" {
 		redisURL = "127.0.0.1:6379"
 	}
-
-	srvURL, err := url.Parse(redisURL)
-	if err != nil {
-		panic("[ERROR] Could not parse REDIS_URL: " + redisURL)
-	}
-
-	if srvURL.User == nil {
-		config.ServerURL = srvURL.String()
-	} else {
-		config.ServerURL = srvURL.Host
-		config.Auth, _ = srvURL.User.Password()
-	}
-
+	config.ServerURL = redisURL
 	return config
 }

--- a/redis/config.go
+++ b/redis/config.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"os"
 	"time"
+
+	"github.com/nhocki/go-longpolling/models"
 )
 
 var (
@@ -18,12 +20,17 @@ const (
 // Config holds the redis configuration
 type Config struct {
 	ServerURL, Auth string
+	Log             models.Logger
 }
 
 // ConfigFromEnv returns a config objects that reads everything from the
 // environment and adds some sensible defaults.
-func ConfigFromEnv() *Config {
-	config := &Config{}
+func ConfigFromEnv(l models.Logger) *Config {
+	if l == nil {
+		l = models.StdLogger
+	}
+
+	config := &Config{Log: l}
 
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {

--- a/redis/pubsub.go
+++ b/redis/pubsub.go
@@ -1,6 +1,7 @@
 package redis
 
 import "github.com/garyburd/redigo/redis"
+import "errors"
 
 // NewPubSub returns a Redis pubsub connection from a config.
 func NewPubSub(cnf *Config) (*redis.PubSubConn, error) {
@@ -14,9 +15,15 @@ func NewPubSub(cnf *Config) (*redis.PubSubConn, error) {
 
 // New returns a new redis connection given some config.
 func New(cnf *Config) (redis.Conn, error) {
-	return redis.Dial(
-		"tcp",
-		cnf.ServerURL,
-		redis.DialPassword(cnf.Auth),
-	)
+	conn, err := redis.Dial("tcp", cnf.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := redis.String(conn.Do("ECHO", "Redis OK"))
+	if (err != nil) || (data != "Redis OK") {
+		return nil, errors.New("could not connect to redis")
+	}
+
+	return conn, err
 }

--- a/strategies/redis.go
+++ b/strategies/redis.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"log"
 
 	"github.com/nhocki/go-longpolling/models"
 	"github.com/nhocki/go-longpolling/redis"
@@ -70,7 +69,7 @@ func (r *Redis) Publish(channel string, rc io.Reader) error {
 		return err
 	}
 	str := readAll(rc)
-	log.Printf("[redis] Publishing to %s: %s", channel, str)
+	r.cnf.Log.Printf("[redis] Publishing to %s: %s", channel, str)
 	c.Do("PUBLISH", channel, str)
 	return c.Close()
 }
@@ -84,12 +83,12 @@ func (r *Redis) receive() {
 	for {
 		switch v := r.PubSubConn.Receive().(type) {
 		case client.Message:
-			log.Printf("[redis] Received on channel %s: %s", v.Channel, string(v.Data))
+			r.cnf.Log.Printf("[redis] Received on channel %s: %s", v.Channel, string(v.Data))
 			r.b.Publish(v.Channel, bytes.NewReader(v.Data))
 		case client.Subscription:
 			// Do nothing
 		case error:
-			log.Println("error pub/sub on connection, delivery has stopped")
+			r.cnf.Log.Printf("error pub/sub on connection, delivery has stopped\n")
 			return
 		}
 	}

--- a/strategies/redis_test.go
+++ b/strategies/redis_test.go
@@ -1,0 +1,50 @@
+package strategies
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/nhocki/go-longpolling/models"
+	"github.com/nhocki/go-longpolling/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleRedisStrategy(t *testing.T) {
+	strategy, err := NewRedisStrategy(redis.ConfigFromEnv())
+	assert.NoError(t, err)
+	strategy.Setup()
+
+	events := models.NewConnection()
+	messages := models.NewConnection()
+
+	assert.NoError(t, strategy.Add(events, "events"))
+	assert.NoError(t, strategy.Add(messages, "messages"))
+
+	assert.Equal(t, 1, strategy.TotalSubs("events"))
+	assert.Equal(t, 1, strategy.TotalSubs("messages"))
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go assertEvent(t, events, wg)
+	go assertNoEvent(t, messages, wg)
+	strategy.Publish("events", bytes.NewReader([]byte(`Hello, World!`)))
+	wg.Wait()
+
+	wg.Add(2)
+	go assertEvent(t, messages, wg)
+	go assertNoEvent(t, events, wg)
+	strategy.Publish("messages", bytes.NewReader([]byte(`Hello, World!`)))
+	wg.Wait()
+
+	assert.Equal(t, 1, strategy.TotalSubs("events"))
+	assert.Equal(t, 1, strategy.TotalSubs("messages"))
+
+	assert.NoError(t, strategy.Remove(events.ID, "events"))
+	assert.NoError(t, strategy.Remove(messages.ID, "events"))
+	assert.NoError(t, strategy.Remove(messages.ID, "messages"))
+	assert.NoError(t, strategy.Remove(messages.ID, "messages"))
+
+	assert.Equal(t, 0, strategy.TotalSubs("events"))
+	assert.Equal(t, 0, strategy.TotalSubs("messages"))
+}

--- a/strategies/redis_test.go
+++ b/strategies/redis_test.go
@@ -10,9 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func newRedisStrategy(t *testing.T) *Redis {
+	cnf := redis.ConfigFromEnv(models.NullLogger)
+	conn, err := redis.NewPubSub(cnf)
+	if err != nil {
+		assert.Fail(t, "Error! %s", err)
+		return nil
+	}
+
+	return &Redis{
+		b:          &Basic{log: models.NullLogger},
+		cnf:        cnf,
+		PubSubConn: conn,
+	}
+}
+
 func TestSingleRedisStrategy(t *testing.T) {
-	strategy, err := NewRedisStrategy(redis.ConfigFromEnv())
-	assert.NoError(t, err)
+	strategy := newRedisStrategy(t)
+	assert.NotNil(t, strategy)
 	strategy.Setup()
 
 	events := models.NewConnection()
@@ -50,11 +65,11 @@ func TestSingleRedisStrategy(t *testing.T) {
 }
 
 func TestMultipleRedisStrategy(t *testing.T) {
-	publisher, err := NewRedisStrategy(redis.ConfigFromEnv())
-	assert.NoError(t, err)
+	publisher := newRedisStrategy(t)
+	assert.NotNil(t, publisher)
 
-	subscriber, err := NewRedisStrategy(redis.ConfigFromEnv())
-	assert.NoError(t, err)
+	subscriber := newRedisStrategy(t)
+	assert.NotNil(t, subscriber)
 
 	// Start subscriber listener
 	subscriber.Setup()


### PR DESCRIPTION
**Sadly, Redis is required to run tests**

This test case simulates multipler servers coordinated by Redis Pub/Sub. When a server gets a subscribe request, it'll keep the connection open and wait for a redis `Receive` event. Once the event happens, it'll forward the message to the subscribers using a Basic strategy.

The `publisher` will send the redis `PUBLISH` command, that will alert all the servers about the event.

In this test case, we have 1 server with two subscribers that gets alerts from one publisher with no subscribers. We test that, even if the publisher has no idea that the two connections are subscribed, when it receives a publish request both subscribers will be alerted.